### PR TITLE
Make more idiomatic English.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ class Model extends Eloquent {
 }
 ```
 By default all model fields are searchable and sortable; all relations can be eagerly loaded by default as well.
-If you need to limit which fields can model be filtered and sorted by and which relations can be loaded, see documentation
+If you need to limit which fields can be filtered and sorted by and which relations can be loaded, see documentation
 of corresponding behaviour package.
 
 ### Pimp your API


### PR DESCRIPTION

Probably don't need the word 'model' and I removed it - there are more verbose ways to "fix" this but I don't believe that would be necessary.